### PR TITLE
use worker_init_fn to split the data

### DIFF
--- a/frameID/data.py
+++ b/frameID/data.py
@@ -1,6 +1,8 @@
 import os
 import csv
 
+import logging
+
 import torch
 import torchvision.transforms as transforms
 from torchvision.io import ImageReadMode, read_image
@@ -142,6 +144,7 @@ class SupervisedFrameDataset(IterableDataset):
         # Check if image is blank
         if self._is_blank(x) or label.item() == 2:
 
+            logging.debug(f"Skipping {p}")
             return next(self)
 
         else:

--- a/frameID/data.py
+++ b/frameID/data.py
@@ -5,7 +5,7 @@ import torch
 import torchvision.transforms as transforms
 from torchvision.io import ImageReadMode, read_image
 
-from torch.utils.data import Dataset, IterableDataset
+from torch.utils.data import Dataset, IterableDataset, get_worker_info
 
 import cv2
 
@@ -34,7 +34,7 @@ def split_iter_workers(worker_id):
     '''
     Each worker operates on a portion of every video (dataset)
     '''
-    info = torch.utils.data.get_worker_info()
+    info = get_worker_info()
     workers = info.num_workers
 
     # For each dataset in the chained dataset, set the starting `curr_frame`

--- a/frameID/data.py
+++ b/frameID/data.py
@@ -30,6 +30,18 @@ def open_video(video_path):
         "height": height,
     }
 
+def split_iter_workers(worker_id):
+    '''
+    Each worker operates on a portion of every video (dataset)
+    '''
+    info = torch.utils.data.get_worker_info()
+    workers = info.num_workers
+
+    # For each dataset in the chained dataset, set the starting `curr_frame`
+    # based on the worker id of the worker (start the iter at worker_id * split size)
+    for ds in info.dataset.datasets:
+        split_size = len(ds) // workers
+        ds.curr_frame = worker_id*split_size
 
 class SupervisedFrameDataset(IterableDataset):
     """Dataset class for basic classification task."""
@@ -130,9 +142,9 @@ class SupervisedFrameDataset(IterableDataset):
 
             return {"x": x, "y": label.long()}
 
-    # def __len__(self):
+    def __len__(self):
 
-    #     return len(self.file_list)
+         return len(self.file_list)
 
 
 class VideoDataset(IterableDataset):

--- a/training_scripts/clean_blanks.py
+++ b/training_scripts/clean_blanks.py
@@ -1,0 +1,39 @@
+import csv
+import os
+
+
+def dedup_label(filename):
+    dedup = {}
+    with open(filename, "r") as f:
+        reader = csv.reader(f, delimiter=",")
+        for row in reader:
+            if dedup.get(int(row[0]), "b") == "b":
+                dedup[int(row[0])] = row[1]
+            else:
+                print(f"skipped frame {int(row[0])} in file {filename}")
+                continue
+    return dedup
+
+
+if __name__ == "__main__":
+
+    train_dirs = [
+        "data/bengals-ravens",
+        "data/browns-ravens",
+        "data/bears-ravens",
+        "data/dolphins-ravens",
+        "data/ravens-browns",
+        "data/ravens-bengals",
+        "data/ravens-packers",
+        "data/steelers-ravens",
+    ]
+
+    train_locs = [f"{d}/frames.csv" for d in train_dirs]
+
+    for f in train_locs:
+        print(f"Processing {f}")
+        deduped = dedup_label(f)
+        with open(f"{os.path.splitext(f)[0]}_clean.csv", "w", newline="") as f:
+            cw = csv.writer(f, delimiter=",")
+            for k, v in deduped.items():
+                cw.writerow((k, v))

--- a/training_scripts/supervised_training.py
+++ b/training_scripts/supervised_training.py
@@ -51,7 +51,7 @@ opt_class = getattr(torch.optim, OPTIMIZER)
 # 100% should come from a config file.
 train_dirs = [
     "data/bengals-ravens",
-    # "data/browns-ravens",
+    "data/browns-ravens",
     "data/bears-ravens",
     "data/dolphins-ravens",
     "data/ravens-browns",
@@ -83,14 +83,14 @@ train_loader = DataLoader(
     batch_size=BATCH_SIZE,
     num_workers=NUM_WORKERS,
     drop_last=False,
-    worker_init_fn=split_iter_workers
+    worker_init_fn=split_iter_workers,
 )
 valid_loader = DataLoader(
     ds_valid,
     batch_size=BATCH_SIZE,
     num_workers=NUM_WORKERS,
     drop_last=False,
-    worker_init_fn=split_iter_workers
+    worker_init_fn=split_iter_workers,
 )
 
 # logging.info(

--- a/training_scripts/supervised_training.py
+++ b/training_scripts/supervised_training.py
@@ -1,5 +1,5 @@
 from frameID.net import FrameConvNet, FrameLinearNet
-from frameID.data import SupervisedFrameDataset
+from frameID.data import SupervisedFrameDataset, split_iter_workers
 
 import torch
 from torch.utils.data import DataLoader, ChainDataset, Subset
@@ -83,12 +83,14 @@ train_loader = DataLoader(
     batch_size=BATCH_SIZE,
     num_workers=NUM_WORKERS,
     drop_last=False,
+    worker_init_fn=split_iter_workers
 )
 valid_loader = DataLoader(
     ds_valid,
     batch_size=BATCH_SIZE,
     num_workers=NUM_WORKERS,
     drop_last=False,
+    worker_init_fn=split_iter_workers
 )
 
 # logging.info(


### PR DESCRIPTION
The idea is to set the `curr_frame` attribute in each of the datasets in the chained iterables to 0, 1/3*length, 2/3*length for each worker so that each worker works on the same portion of each video. 

`get_worker_info().dataset` is the chained dataset, which has the attribute `datasets` which is a list of the underlying iterable datasets